### PR TITLE
Update repo links, split GHA workflows, make Linux wheels more compatible

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -42,7 +42,7 @@ jobs:
       if: "matrix.os == 'ubuntu-20.04'"
       run: |
         pip install -U auditwheel patchelf
-        auditwheel repair --plat manylinux_2_31_x86_64 --wheel-dir dist dist/ada_url-*linux*.whl
+        auditwheel repair --plat manylinux_2_24_x86_64 --wheel-dir dist dist/ada_url-*linux*.whl
     - name: Run tests
       run: |
         pip install -e .

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -35,10 +35,6 @@ jobs:
     - name: Install dependencies
       run: |
         make requirements
-    - name: Static analysis
-      if: "matrix.python == '3.8'"
-      run: |
-        make check
     - name: Build packages
       run: |
         make package

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Build and test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.rst'
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.rst'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        make requirements
+    - name: Static analysis
+      run: |
+        make check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Lint
 
 on:
   pull_request:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ readme_src = os.path.join(parent_dir, 'README.rst')
 readme_dst = os.path.join(build_dir, 'README.pprst')
 shutil.copyfile(readme_src, readme_dst)
 
-project = 'ada-url/python'
+project = 'ada-url/ada-python '
 copyright = '2023, Ada authors'
 author = 'Ada authors'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ readme_src = os.path.join(parent_dir, 'README.rst')
 readme_dst = os.path.join(build_dir, 'README.pprst')
 shutil.copyfile(readme_src, readme_dst)
 
-project = 'ada-url/ada-python '
+project = 'ada-url/ada-python'
 copyright = '2023, Ada authors'
 author = 'Ada authors'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Clone the git repository to a directory for development:
 
 .. code-block:: sh
 
-    git clone https://github.com/ada-url/python/ ada_url_python
+    git clone https://github.com/ada-url/ada-python.git ada_url_python
     cd ada_url_python
 
 Create a virtual environment to use for building:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
 project_urls =
-    homepage = https://github.com/ada-url/python
+    homepage = https://github.com/ada-url/ada-python
 
 [options]
 packages = find:


### PR DESCRIPTION
This PR:
* Changes references to `ada-url/python` to `ada-url/ada-python`
* Splits the GitHub Actions workflows. Building and testing are now separate from linting.
* Updates the compatibility level for Linux wheels. The ones produced by the GHA runners should be able to run on a wider variety of systems.