### PR TITLE
Add directory listing to URL class

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -88,6 +88,9 @@ class URL:
         if not lib.ada_is_valid(self.urlobj):
             raise ValueError('Invalid input')
 
+    def __dir__(self):
+        return super().__dir__() + list(PARSE_ATTRIBUTES)
+
     def __getattr__(self, attr):
         if attr in GET_ATTRIBUTES:
             get_func = getattr(lib, f'ada_get_{attr}')

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -8,6 +8,7 @@ from ada_url import (
     parse_url,
     replace_url,
 )
+from ada_url.ada_adapter import GET_ATTRIBUTES
 
 
 class ADAURLTests(TestCase):
@@ -85,6 +86,12 @@ class ADAURLTests(TestCase):
             with self.subTest(url=url):
                 actual = URL.can_parse(url, base)
                 self.assertEqual(actual, expected)
+
+    def test_class_dir(self):
+        with URL('https://example.org') as urlobj:
+            actual = set(dir(urlobj))
+
+        self.assertTrue(actual.issuperset(GET_ATTRIBUTES))
 
     def test_check_url(self):
         for s, expected in (


### PR DESCRIPTION
This PR exposes the `URL` attributes to the `dir()` function in Python.