### PR TITLE
Use ffi.gc to handle object lifecycle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,9 @@ This package exposes a ``URL`` class that is intended to match the one described
 .. code-block:: python
 
     >>> import ada_url
-    >>> with ada_url.URL('https://example.org/path/../file.txt') as urlobj:
-    ...     urlobj.host = 'example.com'
-    ...     new_url = urlobj.href
+    >>> ada_url.URL('https://example.org/path/../file.txt') as urlobj:
+    >>> urlobj.host = 'example.com'
+    >>> new_url = urlobj.href
     >>> new_url
     'https://example.com/file.txt'
 

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -14,41 +14,41 @@ from ada_url.ada_adapter import GET_ATTRIBUTES
 class ADAURLTests(TestCase):
     def test_class_get(self):
         url = 'https://user_1:password_1@example.org:8080/dir/../api?q=1#frag'
-        with URL(url) as urlobj:
-            self.assertEqual(
-                urlobj.href, 'https://user_1:password_1@example.org:8080/api?q=1#frag'
-            )
-            self.assertEqual(urlobj.username, 'user_1')
-            self.assertEqual(urlobj.password, 'password_1')
-            self.assertEqual(urlobj.protocol, 'https:')
-            self.assertEqual(urlobj.port, '8080')
-            self.assertEqual(urlobj.hostname, 'example.org')
-            self.assertEqual(urlobj.host, 'example.org:8080')
-            self.assertEqual(urlobj.pathname, '/api')
-            self.assertEqual(urlobj.search, '?q=1')
-            self.assertEqual(urlobj.hash, '#frag')
-            self.assertEqual(urlobj.origin, 'https://example.org:8080')
+        urlobj = URL(url)
+        self.assertEqual(
+            urlobj.href, 'https://user_1:password_1@example.org:8080/api?q=1#frag'
+        )
+        self.assertEqual(urlobj.username, 'user_1')
+        self.assertEqual(urlobj.password, 'password_1')
+        self.assertEqual(urlobj.protocol, 'https:')
+        self.assertEqual(urlobj.port, '8080')
+        self.assertEqual(urlobj.hostname, 'example.org')
+        self.assertEqual(urlobj.host, 'example.org:8080')
+        self.assertEqual(urlobj.pathname, '/api')
+        self.assertEqual(urlobj.search, '?q=1')
+        self.assertEqual(urlobj.hash, '#frag')
+        self.assertEqual(urlobj.origin, 'https://example.org:8080')
 
-            with self.assertRaises(AttributeError):
-                urlobj.bogus
+        with self.assertRaises(AttributeError):
+            urlobj.bogus
 
     def test_class_set(self):
         url = 'https://username:password@www.google.com:8080/'
-        with URL(url) as urlobj:
-            urlobj.href = 'https://www.yagiz.co'
-            urlobj.hash = 'new-hash'
-            urlobj.hostname = 'new-host'
-            urlobj.host = 'changed-host:9090'
-            urlobj.pathname = 'new-pathname'
-            urlobj.search = 'new-search'
-            urlobj.protocol = 'wss'
-            actual = urlobj.href
+        urlobj = URL(url)
+        urlobj.href = 'https://www.yagiz.co'
+        urlobj.hash = 'new-hash'
+        urlobj.hostname = 'new-host'
+        urlobj.host = 'changed-host:9090'
+        urlobj.pathname = 'new-pathname'
+        urlobj.search = 'new-search'
+        urlobj.protocol = 'wss'
+        actual = urlobj.href
 
-            with self.assertRaises(ValueError):
-                urlobj.hostname = 1
+        with self.assertRaises(ValueError):
+            urlobj.hostname = 1
 
-            with self.assertRaises(ValueError):
-                urlobj.hostname = '127.0.0.0.0.1'
+        with self.assertRaises(ValueError):
+            urlobj.hostname = '127.0.0.0.0.1'
 
         expected = 'wss://changed-host:9090/new-pathname?new-search#new-hash'
         self.assertEqual(actual, expected)
@@ -56,13 +56,12 @@ class ADAURLTests(TestCase):
     def test_class_with_base(self):
         url = '../example.txt'
         base = 'https://example.org/path/'
-        with URL(url, base) as urlobj:
-            self.assertEqual(urlobj.href, 'https://example.org/example.txt')
+        urlobj = URL(url, base)
+        self.assertEqual(urlobj.href, 'https://example.org/example.txt')
 
     def test_class_invalid(self):
         with self.assertRaises(ValueError):
-            with URL('bogus'):
-                pass
+            URL('bogus')
 
     def test_class_can_parse(self):
         for url, expected in (
@@ -88,9 +87,8 @@ class ADAURLTests(TestCase):
                 self.assertEqual(actual, expected)
 
     def test_class_dir(self):
-        with URL('https://example.org') as urlobj:
-            actual = set(dir(urlobj))
-
+        urlobj = URL('https://example.org')
+        actual = set(dir(urlobj))
         self.assertTrue(actual.issuperset(GET_ATTRIBUTES))
 
     def test_check_url(self):


### PR DESCRIPTION
Re: [this discussion](https://github.com/ada-url/ada-python/pull/1#issuecomment-1553531106), this PR re-works how the objects from the C library are managed.

Previously I was using `__enter__` and `__exit__` to ensure that `ada_free` got called. But CFFI provides [`ffi.gc`](https://cffi.readthedocs.io/en/latest/ref.html#ffi-gc-1), which can do this automatically:
>ffi.gc(cdata, destructor, size=0): return a new cdata object that points to the same data. Later, when this new cdata object is garbage-collected, destructor(old_cdata_object) will be called

This allows us to avoid the overhead of `__enter__` and `__exit__`. On a benchmark script this saved roughly 20% of execution time.