### PR TITLE
Upgrade ada C library to 2.4.2

### DIFF
--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-05-16 13:48:47 -0400. Do not edit! */
+/* auto-generated on 2023-05-19 00:02:33 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -4354,8 +4354,9 @@ ada_really_inline constexpr bool contains_forbidden_domain_code_point(
  * then the second bit is set to 1.
  * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
  */
-ada_really_inline constexpr bool contains_forbidden_domain_code_point_or_upper(
-    const char* input, size_t length) noexcept;
+ada_really_inline constexpr uint8_t
+contains_forbidden_domain_code_point_or_upper(const char* input,
+                                              size_t length) noexcept;
 
 /**
  * Checks if the input is a forbidden doamin code point.
@@ -6484,14 +6485,14 @@ inline std::ostream &operator<<(std::ostream &out,
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.4.1"
+#define ADA_VERSION "2.4.2"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 4,
-  ADA_VERSION_REVISION = 1,
+  ADA_VERSION_REVISION = 2,
 };
 
 }  // namespace ada


### PR DESCRIPTION
This PR synchronizes the C library with the newly-released 2.4.2 version of `ada`.