### PR TITLE
Add __str__ and __repr__ methods

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -123,7 +123,7 @@ class URL:
             return ret
 
         return super().__setattr__(attr, value)
-    
+
     def __str__(self):
         return self.href
 

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -123,6 +123,12 @@ class URL:
             return ret
 
         return super().__setattr__(attr, value)
+    
+    def __str__(self):
+        return self.href
+
+    def __repr__(self):
+        return f'<URL "{self.href}">'
 
     @staticmethod
     def can_parse(url, base=None):

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -91,6 +91,18 @@ class ADAURLTests(TestCase):
         actual = set(dir(urlobj))
         self.assertTrue(actual.issuperset(GET_ATTRIBUTES))
 
+    def test_to_str(self):
+        urlobj = URL('https://example.org/../something.txt')
+        actual = str(urlobj)
+        expected = 'https://example.org/something.txt'
+        self.assertEqual(actual, expected)
+
+    def test_to_repr(self):
+        urlobj = URL('https://example.org/../something.txt')
+        actual = repr(urlobj)
+        expected = '<URL "https://example.org/something.txt">'
+        self.assertEqual(actual, expected)
+
     def test_check_url(self):
         for s, expected in (
             ('https:example.org', True),


### PR DESCRIPTION
This PR adds `__str__` and `__repr__` methods to the `URL` class, such that objects now return a friendly representation based on their `href`.