### PR TITLE
Build wheels with cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.3
     - name: Upload packages
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v3
       with:
         name: ada-url-packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.rst'
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.rst'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
+jobs:
+  build_wheels:
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04", "macos-11"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        make requirements c_lib
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.12.3
+    - name: Upload packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: ada-url-packages
+        path: wheelhouse/*

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04", "macos-11"]
-        python: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Unit tests
 
 on:
   pull_request:
@@ -21,38 +21,27 @@ jobs:
   build_test:
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "macos-latest"]
+        os: ["ubuntu-20.04", "macos-11"]
         python: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python }}
+        python-version: "3.8"
     - name: Install dependencies
       run: |
         make requirements
     - name: Build packages
       run: |
         make package
-    - name: Repair wheels
-      if: "matrix.os == 'ubuntu-20.04'"
-      run: |
-        pip install -U auditwheel patchelf
-        auditwheel repair --plat manylinux_2_24_x86_64 --wheel-dir dist dist/ada_url-*linux*.whl
     - name: Run tests
       run: |
         pip install -e .
         make coverage
-    - name: Build docs with sphinx
-      if: "matrix.python == '3.8' && matrix.os == 'ubuntu-20.04'"
+    - name: Check docs
       run: |
         make docs
-    - name: Upload packages
-      uses: actions/upload-artifact@v3
-      with:
-        name: ada-url-packages
-        path: dist/*

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,11 @@ clean:
 	$(RM) ada_url/_ada_wrapper.abi3.so
 	$(RM) ada_url/ada.o
 
-.PHONY: package
-package:
+.PHONY: c_lib
+c_lib:
 	$(CXX) -c "ada_url/ada.cpp" -fPIC -std="c++17" -O2 -o "ada_url/ada.o"
+
+.PHONY: package
+package: c_lib
 	python -m build --no-isolation
 	twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,19 @@ exclude = [
     ".git",
     ".ruff_cache",
 ]
+
+[tool.cibuildwheel]
+build = [
+    "cp38-*",
+    "cp39-*",
+    "cp310-*",
+    "cp311-*",
+    "pp38-*",
+    "pp39-*",
+]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2", "arm64"]


### PR DESCRIPTION
This PR updates the build configuration for GitHub Actions, such that more compatible wheels are produced.

I was previously using `auditwheel` manually for Linux builds; this function is now performed by `cibuildwheel`.

macOS builds are also more compatible, using `delocate`.

These are the ones I'll post to PyPI.