### PR TITLE
Docs conf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_install:
+      - make package
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,7 @@ build:
     pre_install:
       - make requirements
       - make package
+      - python -m pip install -e .
 sphinx:
    configuration: docs/conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
     python: "3.11"
   jobs:
     pre_install:
+      - make requirements
       - make package
 sphinx:
    configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -74,3 +74,5 @@ It also provides some higher level functions for parsing and manipulating URLs.
     }
     >>> ada_url.replace_url('http://example.org:80', protocol='https:')
     'https://example.org/'
+
+You can find more documentation at `Read the Docs <https://ada-url.readthedocs.io>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,11 +50,3 @@ API Documentation
 
 .. automodule:: ada_url
     :members:
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
This PR adds `.readthedocs.yaml` for building the full documentation, which is displayed [here](https://ada-url.readthedocs.io/en/docs-conf/).

Closes #9.