### PR TITLE
Update example for URL.can_parse

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -65,8 +65,8 @@ class URL:
 
     .. code-block:: python
 
-        >>> url = 'https://example.org:443/file_1.txt'
-        >>> base = 'file_2.txt'
+        >>> url = 'file_2.txt'
+        >>> base = 'https://example.org:443/file_1.txt'
         >>> URL.can_parse(url, base)
         True
 


### PR DESCRIPTION
This PR fixes a mistake in the docstring for `ada_url.URL.can_parse`. The `base` and `url` arguments were reversed.