### PR TITLE
Bump version to 1.0.1 for ada 2.5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ada-url
-version = 1.0.0
+version = 1.0.1
 description = 'URL parser and manipulator based on the WHAT WG URL standard'
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
This PR updates the version number for the package. I'll release this to PyPI, so users can get the ada 2.5.1 changes.