### PR TITLE
Publish to PyPI on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
       - '**.rst'
       - 'docs/**'
 
+   release:
+     types:
+       - published
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@v3
-    - run: python -m build --no-isolation --sdist
+    - run: |
+      make requirements
+      python -m build --no-isolation --sdist
     - uses: actions/upload-artifact@v3
       with:
         path: dist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,20 +21,37 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "macos-11"]
+        os: ["ubuntu-latest", "macos-11"]
 
     runs-on: ${{ matrix.os }}
-
     steps:
     - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: |
-        make requirements c_lib
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.3
-    - name: Upload packages
-      if: github.event_name == 'push'
-      uses: actions/upload-artifact@v3
+    - run: make requirements c_lib
+    - uses: pypa/cibuildwheel@v2.13.0
+    - uses: actions/upload-artifact@v3
       with:
         name: ada-url-packages
-        path: wheelhouse/*
+        path: wheelhouse/*.whl
+
+  make_sdist:
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+    - run: python -m build --no-isolation --sdist
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    runs-on: "ubuntu-latest"
+    environment: release
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ada-url-packages
+        path: wheelhouse
+    - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
     - uses: pypa/cibuildwheel@v2.13.0
     - uses: actions/upload-artifact@v3
       with:
-        name: ada-url-packages
         path: wheelhouse/*.whl
 
   make_sdist:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-11"]
+        os: ["ubuntu-latest", "macos-latest"]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Re: Issue #15, this PR updates the `build.yml` file such that:
* The action runs when a new GitHub release is created
* A source distribution (`.tar.gz`) is created
* The source distribution and binary distributions (`.whl`) are uploaded to PyPI

I am drawing from these docs:
* [`cibuildwheel/examples/github-deploy.yml`](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml)
* [Publishing with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/)

I have created a GitHub "environment" called `release` for publishing. I will [configure PyPI](https://github.com/ada-url/ada-python/assets/1922815/53676601-9afe-4ee7-8e78-23cde147a1bb) to use it as well.