### PR TITLE
Fix another build.yml syntax error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: |
-      make requirements
-      python -m build --no-isolation --sdist
+        make requirements
+        python -m build --no-isolation --sdist
     - uses: actions/upload-artifact@v3
       with:
         path: dist/*.tar.gz


### PR DESCRIPTION
Like https://github.com/ada-url/ada-python/pull/17, but for later in the file. The linter now thinks the YAML file is valid...