### PR TITLE
Fix artifact name for package release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,5 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: ada-url-packages
         path: wheelhouse
     - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR updates `build.yml` to fix [this issue](https://github.com/ada-url/ada-python/actions/runs/5189343000/jobs/9354691643) that affects the automated release.