### PR TITLE
Fix download-artifact name and path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,5 +56,6 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        path: wheelhouse
+        name: artifact
+        path: dist
     - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Hopefully the last change needed for #15: this PR updates the `download-artifact` parameters for the upload to PyPI.

The `cibuildwheel` repo explains why this is needed [here](https://github.com/pypa/cibuildwheel/commit/c4bfbe2ef1e6f39f1f575d6b573e96998b5d687b).