### PR TITLE
Version 1.2.0: ada_url to 2.6.5, host_type support

### DIFF
--- a/ada_url/__init__.py
+++ b/ada_url/__init__.py
@@ -1,5 +1,6 @@
 from ada_url.ada_adapter import (
     URL,
+    URLHostType,
     check_url,
     idna,
     idna_to_ascii,
@@ -12,6 +13,7 @@ from ada_url.ada_adapter import (
 
 __all__ = [
     'URL',
+    'URLHostType',
     'check_url',
     'idna',
     'idna_to_ascii',

--- a/ada_url/__init__.py
+++ b/ada_url/__init__.py
@@ -1,6 +1,6 @@
 from ada_url.ada_adapter import (
     URL,
-    URLHostType,
+    HostType,
     check_url,
     idna,
     idna_to_ascii,
@@ -13,7 +13,7 @@ from ada_url.ada_adapter import (
 
 __all__ = [
     'URL',
-    'URLHostType',
+    'HostType',
     'check_url',
     'idna',
     'idna_to_ascii',

--- a/ada_url/ada.cpp
+++ b/ada_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-28 15:54:13 -0400. Do not edit! */
+/* auto-generated on 2023-08-30 11:44:21 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -116,10 +116,11 @@ ada_really_inline constexpr bool verify_dns_length(
 
 ADA_PUSH_DISABLE_ALL_WARNINGS
 /* begin file src/ada_idna.cpp */
-/* auto-generated on 2023-05-07 19:12:14 -0400. Do not edit! */
+/* auto-generated on 2023-08-29 15:28:19 -0400. Do not edit! */
 /* begin file src/idna.cpp */
 /* begin file src/unicode_transcoding.cpp */
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 
@@ -226,38 +227,22 @@ size_t utf8_length_from_utf32(const char32_t* buf, size_t len) {
   // We are not BOM aware.
   const uint32_t* p = reinterpret_cast<const uint32_t*>(buf);
   size_t counter{0};
-  for (size_t i = 0; i < len; i++) {
-    /** ASCII **/
-    if (p[i] <= 0x7F) {
-      counter++;
-    }
-    /** two-byte **/
-    else if (p[i] <= 0x7FF) {
-      counter += 2;
-    }
-    /** three-byte **/
-    else if (p[i] <= 0xFFFF) {
-      counter += 3;
-    }
-    /** four-bytes **/
-    else {
-      counter += 4;
-    }
+  for (size_t i = 0; i != len; ++i) {
+    ++counter;                                      // ASCII
+    counter += static_cast<size_t>(p[i] > 0x7F);    // two-byte
+    counter += static_cast<size_t>(p[i] > 0x7FF);   // three-byte
+    counter += static_cast<size_t>(p[i] > 0xFFFF);  // four-bytes
   }
   return counter;
 }
 
 size_t utf32_length_from_utf8(const char* buf, size_t len) {
   const int8_t* p = reinterpret_cast<const int8_t*>(buf);
-  size_t counter{0};
-  for (size_t i = 0; i < len; i++) {
+  return std::count_if(p, std::next(p, len), [](int8_t c) {
     // -65 is 0b10111111, anything larger in two-complement's
     // should start a new code point.
-    if (p[i] > -65) {
-      counter++;
-    }
-  }
-  return counter;
+    return c > -65;
+  });
 }
 
 size_t utf32_to_utf8(const char32_t* buf, size_t len, char* utf8_output) {
@@ -9525,14 +9510,14 @@ bool constexpr begins_with(std::u32string_view view,
   if (view.size() < prefix.size()) {
     return false;
   }
-  return view.substr(0, prefix.size()) == prefix;
+  return std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 
 bool constexpr begins_with(std::string_view view, std::string_view prefix) {
   if (view.size() < prefix.size()) {
     return false;
   }
-  return view.substr(0, prefix.size()) == prefix;
+  return std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 
 bool constexpr is_ascii(std::u32string_view view) {
@@ -10144,13 +10129,12 @@ ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
 }
 
+constexpr static char hex_to_binary_table[] = {
+    0,  1,  2,  3,  4, 5, 6, 7, 8, 9, 0, 0,  0,  0,  0,  0,  0, 10, 11,
+    12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0, 0,  0,
+    0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13, 14, 15};
 unsigned constexpr convert_hex_to_binary(const char c) noexcept {
-  // this code can be optimized.
-  if (c <= '9') {
-    return c - '0';
-  }
-  char del = c >= 'a' ? 'a' : 'A';
-  return 10 + (c - del);
+  return hex_to_binary_table[c - '0'];
 }
 
 std::string percent_decode(const std::string_view input, size_t first_percent) {
@@ -15094,6 +15078,13 @@ bool ada_set_pathname(ada_url result, const char* input,
   return r->set_pathname(std::string_view(input, length));
 }
 
+/**
+ * Update the search/query of the URL.
+ *
+ * If a URL has `?` as the search value, passing empty string to this function
+ * does not remove the attribute. If you need to remove it, please use
+ * `ada_clear_search` method.
+ */
 void ada_set_search(ada_url result, const char* input, size_t length) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (r) {
@@ -15101,6 +15092,13 @@ void ada_set_search(ada_url result, const char* input, size_t length) noexcept {
   }
 }
 
+/**
+ * Update the hash/fragment of the URL.
+ *
+ * If a URL has `#` as the hash value, passing empty string to this function
+ * does not remove the attribute. If you need to remove it, please use
+ * `ada_clear_hash` method.
+ */
 void ada_set_hash(ada_url result, const char* input, size_t length) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (r) {
@@ -15115,6 +15113,12 @@ void ada_clear_port(ada_url result) noexcept {
   }
 }
 
+/**
+ * Removes the hash of the URL.
+ *
+ * Despite `ada_set_hash` method, this function allows the complete
+ * removal of the hash attribute, even if it has a value of `#`.
+ */
 void ada_clear_hash(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (r) {
@@ -15122,13 +15126,12 @@ void ada_clear_hash(ada_url result) noexcept {
   }
 }
 
-void ada_clear_pathname(ada_url result) noexcept {
-  ada::result<ada::url_aggregator>& r = get_instance(result);
-  if (r) {
-    r->clear_pathname();
-  }
-}
-
+/**
+ * Removes the search of the URL.
+ *
+ * Despite `ada_set_search` method, this function allows the complete
+ * removal of the search attribute, even if it has a value of `?`.
+ */
 void ada_clear_search(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (r) {

--- a/ada_url/ada.cpp
+++ b/ada_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-26 17:38:28 -0400. Do not edit! */
+/* auto-generated on 2023-08-28 15:54:13 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -10159,8 +10159,9 @@ std::string percent_decode(const std::string_view input, size_t first_percent) {
   if (first_percent == std::string_view::npos) {
     return std::string(input);
   }
-  std::string dest(input.substr(0, first_percent));
+  std::string dest;
   dest.reserve(input.length());
+  dest.append(input.substr(0, first_percent));
   const char* pointer = input.data() + first_percent;
   const char* end = input.data() + input.size();
   // Optimization opportunity: if the following code gets
@@ -10197,9 +10198,10 @@ std::string percent_encode(const std::string_view input,
     return std::string(input);
   }
 
-  std::string result(input.substr(0, std::distance(input.begin(), pointer)));
+  std::string result;
   result.reserve(input.length());  // in the worst case, percent encoding might
                                    // produce 3 characters.
+  result.append(input.substr(0, std::distance(input.begin(), pointer)));
 
   for (; pointer != input.end(); pointer++) {
     if (character_sets::bit_at(character_set, *pointer)) {
@@ -15015,7 +15017,7 @@ ada_string ada_get_protocol(ada_url result) noexcept {
   return ada_string_create(out.data(), out.length());
 }
 
-uint8_t ada_get_url_host_type(ada_url result) noexcept {
+uint8_t ada_get_host_type(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (!r) {
     return 0;
@@ -15103,6 +15105,34 @@ void ada_set_hash(ada_url result, const char* input, size_t length) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (r) {
     r->set_hash(std::string_view(input, length));
+  }
+}
+
+void ada_clear_port(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_port();
+  }
+}
+
+void ada_clear_hash(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_hash();
+  }
+}
+
+void ada_clear_pathname(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_pathname();
+  }
+}
+
+void ada_clear_search(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_search();
   }
 }
 

--- a/ada_url/ada.cpp
+++ b/ada_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-07-23 15:03:22 -0400. Do not edit! */
+/* auto-generated on 2023-08-26 17:38:28 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -11231,6 +11231,7 @@ final:
   } else {
     host = ada::serializers::ipv4(ipv4);  // We have to reserialize the address.
   }
+  host_type = IPV4;
   return true;
 }
 
@@ -11460,6 +11461,7 @@ bool url::parse_ipv6(std::string_view input) {
   }
   host = ada::serializers::ipv6(address);
   ada_log("parse_ipv6 ", *host);
+  host_type = IPV6;
   return true;
 }
 
@@ -12569,7 +12571,6 @@ result_type parse_url(std::string_view user_input,
         // If c is U+002F (/) and remaining starts with U+002F (/),
         // then set state to special authority ignore slashes state and increase
         // pointer by 1.
-        state = ada::state::SPECIAL_AUTHORITY_IGNORE_SLASHES;
         std::string_view view = helpers::substring(url_data, input_position);
         if (ada::checkers::begins_with(view, "//")) {
           input_position += 2;
@@ -14021,6 +14022,7 @@ final:
     update_base_hostname(
         ada::serializers::ipv4(ipv4));  // We have to reserialize the address.
   }
+  host_type = IPV4;
   ADA_ASSERT_TRUE(validate());
   return true;
 }
@@ -14256,6 +14258,7 @@ bool url_aggregator::parse_ipv6(std::string_view input) {
   update_base_hostname(ada::serializers::ipv6(address));
   ada_log("parse_ipv6 ", get_hostname());
   ADA_ASSERT_TRUE(validate());
+  host_type = IPV6;
   return true;
 }
 
@@ -14890,6 +14893,11 @@ void ada_free(ada_url result) noexcept {
   delete r;
 }
 
+ada_url ada_copy(ada_url input) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(input);
+  return new ada::result<ada::url_aggregator>(r);
+}
+
 bool ada_is_valid(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   return r.has_value();
@@ -15005,6 +15013,14 @@ ada_string ada_get_protocol(ada_url result) noexcept {
   }
   std::string_view out = r->get_protocol();
   return ada_string_create(out.data(), out.length());
+}
+
+uint8_t ada_get_url_host_type(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (!r) {
+    return 0;
+  }
+  return r->host_type;
 }
 
 bool ada_set_href(ada_url result, const char* input, size_t length) noexcept {

--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-28 15:54:13 -0400. Do not edit! */
+/* auto-generated on 2023-08-30 11:44:21 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -8,7 +8,7 @@
 #define ADA_H
 
 /* begin file include/ada/ada_idna.h */
-/* auto-generated on 2023-05-07 19:12:14 -0400. Do not edit! */
+/* auto-generated on 2023-08-29 15:28:19 -0400. Do not edit! */
 /* begin file include/idna.h */
 #ifndef ADA_IDNA_H
 #define ADA_IDNA_H
@@ -4584,9 +4584,10 @@ ada_really_inline constexpr bool is_single_dot_path_segment(
 ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept;
 
 /**
- * @details Convert hex to binary.
+ * @details Convert hex to binary. Caller is responsible to ensure that
+ * the parameter is an hexadecimal digit (0-9, A-F, a-f).
  */
-unsigned constexpr convert_hex_to_binary(char c) noexcept;
+ada_really_inline unsigned constexpr convert_hex_to_binary(char c) noexcept;
 
 /**
  * first_percent should be  = input.find('%')
@@ -4842,7 +4843,6 @@ struct url_aggregator : url_base {
 
   inline void clear_port();
   inline void clear_hash();
-  inline void clear_pathname() override;
   inline void clear_search() override;
 
  private:
@@ -4921,6 +4921,7 @@ struct url_aggregator : url_base {
   inline uint32_t retrieve_base_port() const;
   inline void clear_hostname();
   inline void clear_password();
+  inline void clear_pathname() override;
   inline bool has_dash_dot() const noexcept;
   void delete_dash_dot();
   inline void consume_prepared_path(std::string_view input);
@@ -6925,14 +6926,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.4"
+#define ADA_VERSION "2.6.5"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 4,
+  ADA_VERSION_REVISION = 5,
 };
 
 }  // namespace ada

--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-07-23 15:03:22 -0400. Do not edit! */
+/* auto-generated on 2023-08-26 17:38:28 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -1008,6 +1008,7 @@ ada_really_inline bool bit_at(const uint8_t a[], const uint8_t i) {
 #define ADA_CHECKERS_INL_H
 
 
+#include <algorithm>
 #include <string_view>
 #include <cstring>
 
@@ -1058,7 +1059,7 @@ ada_really_inline constexpr bool begins_with(std::string_view view,
                                              std::string_view prefix) {
   // in C++20, you have view.begins_with(prefix)
   return view.size() >= prefix.size() &&
-         (view.substr(0, prefix.size()) == prefix);
+         std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 
 }  // namespace ada::checkers
@@ -1407,6 +1408,25 @@ constexpr ada::scheme::type get_scheme_type(std::string_view scheme) noexcept;
 namespace ada {
 
 /**
+ * Type of URL host as an enum.
+ */
+enum url_host_type : uint8_t {
+  /**
+   * Represents common URLs such as "https://www.google.com"
+   */
+  DEFAULT = 0,
+  /**
+   * Represents ipv4 addresses such as "http://127.0.0.1"
+   */
+  IPV4 = 1,
+  /**
+   * Represents ipv6 addresses such as
+   * "http://[2001:db8:3333:4444:5555:6666:7777:8888]"
+   */
+  IPV6 = 2,
+};
+
+/**
  * @brief Base class of URL implementations
  *
  * @details A url_base contains a few attributes: is_valid, has_opaque_path and
@@ -1427,6 +1447,11 @@ struct url_base {
    * A URL has an opaque path if its path is a string.
    */
   bool has_opaque_path{false};
+
+  /**
+   * URL hosts type
+   */
+  url_host_type host_type = url_host_type::DEFAULT;
 
   /**
    * @private
@@ -1768,8 +1793,8 @@ inline int fast_digit_count(uint32_t x) noexcept {
 #define TL_EXPECTED_HPP
 
 #define TL_EXPECTED_VERSION_MAJOR 1
-#define TL_EXPECTED_VERSION_MINOR 0
-#define TL_EXPECTED_VERSION_PATCH 1
+#define TL_EXPECTED_VERSION_MINOR 1
+#define TL_EXPECTED_VERSION_PATCH 0
 
 #include <exception>
 #include <functional>
@@ -1800,6 +1825,16 @@ inline int fast_digit_count(uint32_t x) noexcept {
 #if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 5 && \
      !defined(__clang__))
 #define TL_EXPECTED_GCC55
+#endif
+
+#if !defined(TL_ASSERT)
+// can't have assert in constexpr in C++11 and GCC 4.9 has a compiler bug
+#if (__cplusplus > 201103L) && !defined(TL_EXPECTED_GCC49)
+#include <cassert>
+#define TL_ASSERT(x) assert(x)
+#else
+#define TL_ASSERT(x)
+#endif
 #endif
 
 #if (defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 && \
@@ -1957,6 +1992,7 @@ template <typename E>
 #ifdef TL_EXPECTED_EXCEPTIONS_ENABLED
   throw std::forward<E>(e);
 #else
+  (void)e;
 #ifdef _MSC_VER
   __assume(0);
 #else
@@ -2597,7 +2633,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
       geterr().~unexpected<E>();
       construct(std::move(rhs).get());
     } else {
-      assign_common(rhs);
+      assign_common(std::move(rhs));
     }
   }
 
@@ -2960,7 +2996,7 @@ struct default_constructor_tag {
 };
 
 // expected_default_ctor_base will ensure that expected has a deleted default
-// constructor if T is not default constructible.
+// consturctor if T is not default constructible.
 // This specialization is for when T is default constructible
 template <class T, class E,
           bool Enable =
@@ -3252,6 +3288,53 @@ class expected : private detail::expected_move_assign_base<T, E>,
   constexpr decltype(map_error_impl(std::declval<const expected &&>(),
                                     std::declval<F &&>()))
   map_error(F &&f) const && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+#if defined(TL_EXPECTED_CXX14) && !defined(TL_EXPECTED_GCC49) && \
+    !defined(TL_EXPECTED_GCC54) && !defined(TL_EXPECTED_GCC55)
+  template <class F>
+  TL_EXPECTED_11_CONSTEXPR auto transform_error(F &&f) & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  TL_EXPECTED_11_CONSTEXPR auto transform_error(F &&f) && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr auto transform_error(F &&f) const & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  constexpr auto transform_error(F &&f) const && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+#else
+  template <class F>
+  TL_EXPECTED_11_CONSTEXPR decltype(map_error_impl(std::declval<expected &>(),
+                                                   std::declval<F &&>()))
+  transform_error(F &&f) & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  TL_EXPECTED_11_CONSTEXPR decltype(map_error_impl(std::declval<expected &&>(),
+                                                   std::declval<F &&>()))
+  transform_error(F &&f) && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr decltype(map_error_impl(std::declval<const expected &>(),
+                                    std::declval<F &&>()))
+  transform_error(F &&f) const & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef TL_EXPECTED_NO_CONSTRR
+  template <class F>
+  constexpr decltype(map_error_impl(std::declval<const expected &&>(),
+                                    std::declval<F &&>()))
+  transform_error(F &&f) const && {
     return map_error_impl(std::move(*this), std::forward<F>(f));
   }
 #endif
@@ -3697,27 +3780,37 @@ class expected : private detail::expected_move_assign_base<T, E>,
     }
   }
 
-  constexpr const T *operator->() const { return valptr(); }
-  TL_EXPECTED_11_CONSTEXPR T *operator->() { return valptr(); }
+  constexpr const T *operator->() const {
+    TL_ASSERT(has_value());
+    return valptr();
+  }
+  TL_EXPECTED_11_CONSTEXPR T *operator->() {
+    TL_ASSERT(has_value());
+    return valptr();
+  }
 
   template <class U = T,
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
   constexpr const U &operator*() const & {
+    TL_ASSERT(has_value());
     return val();
   }
   template <class U = T,
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
   TL_EXPECTED_11_CONSTEXPR U &operator*() & {
+    TL_ASSERT(has_value());
     return val();
   }
   template <class U = T,
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
   constexpr const U &&operator*() const && {
+    TL_ASSERT(has_value());
     return std::move(val());
   }
   template <class U = T,
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
   TL_EXPECTED_11_CONSTEXPR U &&operator*() && {
+    TL_ASSERT(has_value());
     return std::move(val());
   }
 
@@ -3753,10 +3846,22 @@ class expected : private detail::expected_move_assign_base<T, E>,
     return std::move(val());
   }
 
-  constexpr const E &error() const & { return err().value(); }
-  TL_EXPECTED_11_CONSTEXPR E &error() & { return err().value(); }
-  constexpr const E &&error() const && { return std::move(err().value()); }
-  TL_EXPECTED_11_CONSTEXPR E &&error() && { return std::move(err().value()); }
+  constexpr const E &error() const & {
+    TL_ASSERT(!has_value());
+    return err().value();
+  }
+  TL_EXPECTED_11_CONSTEXPR E &error() & {
+    TL_ASSERT(!has_value());
+    return err().value();
+  }
+  constexpr const E &&error() const && {
+    TL_ASSERT(!has_value());
+    return std::move(err().value());
+  }
+  TL_EXPECTED_11_CONSTEXPR E &&error() && {
+    TL_ASSERT(!has_value());
+    return std::move(err().value());
+  }
 
   template <class U>
   constexpr T value_or(U &&v) const & {
@@ -6609,6 +6714,7 @@ struct url_search_params {
    * @see https://url.spec.whatwg.org/#dom-urlsearchparams-has
    */
   inline bool has(std::string_view key) noexcept;
+  inline bool has(std::string_view key, std::string_view value) noexcept;
 
   /**
    * @see https://url.spec.whatwg.org/#dom-urlsearchparams-set
@@ -6733,6 +6839,15 @@ inline bool url_search_params::has(const std::string_view key) noexcept {
   return entry != params.end();
 }
 
+inline bool url_search_params::has(std::string_view key,
+                                   std::string_view value) noexcept {
+  auto entry =
+      std::find_if(params.begin(), params.end(), [&key, &value](auto &param) {
+        return param.first == key && param.second == value;
+      });
+  return entry != params.end();
+}
+
 inline std::string url_search_params::to_string() {
   auto character_set = ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE;
   std::string out{};
@@ -6807,14 +6922,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.0"
+#define ADA_VERSION "2.6.3"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 0,
+  ADA_VERSION_REVISION = 3,
 };
 
 }  // namespace ada

--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-26 17:38:28 -0400. Do not edit! */
+/* auto-generated on 2023-08-28 15:54:13 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -4840,6 +4840,11 @@ struct url_aggregator : url_base {
   /** @return true if the URL has a search component */
   [[nodiscard]] inline bool has_search() const noexcept override;
 
+  inline void clear_port();
+  inline void clear_hash();
+  inline void clear_pathname() override;
+  inline void clear_search() override;
+
  private:
   friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(
       std::string_view, const ada::url_aggregator *);
@@ -4914,11 +4919,7 @@ struct url_aggregator : url_base {
   inline void update_base_port(uint32_t input);
   inline void append_base_pathname(const std::string_view input);
   inline uint32_t retrieve_base_port() const;
-  inline void clear_port();
   inline void clear_hostname();
-  inline void clear_hash();
-  inline void clear_pathname() override;
-  inline void clear_search() override;
   inline void clear_password();
   inline bool has_dash_dot() const noexcept;
   void delete_dash_dot();
@@ -6448,7 +6449,9 @@ inline void url_aggregator::clear_hostname() {
                        " with " + components.to_string() + "\n" + to_diagram());
 #endif
   ADA_ASSERT_TRUE(has_authority());
-  ADA_ASSERT_TRUE(has_empty_hostname());
+  ADA_ASSERT_EQUAL(has_empty_hostname(), true,
+                   "hostname should have been cleared on buffer=" + buffer +
+                       " with " + components.to_string() + "\n" + to_diagram());
   ADA_ASSERT_TRUE(validate());
 }
 
@@ -6922,14 +6925,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.3"
+#define ADA_VERSION "2.6.4"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 3,
+  ADA_VERSION_REVISION = 4,
 };
 
 }  // namespace ada

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -124,6 +124,21 @@ class URL:
         if not lib.ada_is_valid(self.urlobj):
             raise ValueError('Invalid input')
 
+    def __copy__(self):
+        cls = self.__class__
+        ret = cls.__new__(cls)
+        ret.__dict__.update(self.__dict__)
+        super(URL, ret).__init__()
+        return ret
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        ret = cls.__new__(cls)
+        super(URL, ret).__init__()
+        ret.urlobj = lib.ada_copy(self.urlobj)
+
+        return ret
+
     def __dir__(self):
         return super().__dir__() + list(PARSE_ATTRIBUTES)
 

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -21,6 +21,25 @@ SET_ATTRIBUTES = frozenset(URL_ATTRIBUTES)
 
 
 class URLHostType(IntEnum):
+    """
+    Enum for URL host types:
+
+    * ``DEFAULT`` hosts like ``https://example.org`` are ``0``.
+    * ``IPV4`` hosts like ``https://192.0.2.1`` are ``1``.
+    * ``IPV6`` hosts like ``https://[2001:db8::]`` are ``2``.
+
+    .. code-block:: python
+
+        >>> from ada_url import URLHostType
+        >>> URLHostType.DEFAULT
+        <URLHostType.DEFAULT: 0>
+        >>> URLHostType.IPV4
+        <URLHostType.IPV4: 1>
+        >>> URLHostType.IPV6
+        <URLHostType.IPV6: 2>
+
+    """
+
     DEFAULT = 0
     IPV4 = 1
     IPV6 = 2
@@ -67,8 +86,7 @@ class URL:
     * ``search``
 
     You can additionally read the ``origin`` and ``url_host_type`` attributes.
-    ``url_host_type`` is an enum with 0 for default hosts, 1 for IPv4 hosts, and 2 for
-    IPv6 hosts.
+    ``url_host_type`` is a :class:`URLHostType` enum.
 
     The class also exposes a static method that checks whether the input
     *url* (and optional *base*) can be parsed:
@@ -262,8 +280,7 @@ def parse_url(s, attributes=PARSE_ATTRIBUTES):
 
     The names of the dictionary keys correspond to the components of the "URL class"
     in the WHATWG URL spec.
-    ``url_host_type`` is an enum with 0 for default hosts, 1 for IPv4 hosts, and 2 for
-    IPv6 hosts.
+    ``url_host_type`` is a :class:`URLHostType` enum.
 
     Pass in a sequence of *attributes* to limit which keys are returned.
 

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -14,13 +14,13 @@ URL_ATTRIBUTES = (
     'search',
     'hash',
 )
-PARSE_ATTRIBUTES = URL_ATTRIBUTES + ('origin', 'url_host_type')
+PARSE_ATTRIBUTES = URL_ATTRIBUTES + ('origin', 'host_type')
 
 GET_ATTRIBUTES = frozenset(PARSE_ATTRIBUTES)
 SET_ATTRIBUTES = frozenset(URL_ATTRIBUTES)
 
 
-class URLHostType(IntEnum):
+class HostType(IntEnum):
     """
     Enum for URL host types:
 
@@ -30,13 +30,13 @@ class URLHostType(IntEnum):
 
     .. code-block:: python
 
-        >>> from ada_url import URLHostType
-        >>> URLHostType.DEFAULT
-        <URLHostType.DEFAULT: 0>
-        >>> URLHostType.IPV4
-        <URLHostType.IPV4: 1>
-        >>> URLHostType.IPV6
-        <URLHostType.IPV6: 2>
+        >>> from ada_url import HostType
+        >>> HostType.DEFAULT
+        <HostType.DEFAULT: 0>
+        >>> HostType.IPV4
+        <HostType.IPV4: 1>
+        >>> HostType.IPV6
+        <HostType.IPV6: 2>
 
     """
 
@@ -85,8 +85,8 @@ class URL:
     * ``pathname``
     * ``search``
 
-    You can additionally read the ``origin`` and ``url_host_type`` attributes.
-    ``url_host_type`` is a :class:`URLHostType` enum.
+    You can additionally read the ``origin`` and ``host_type`` attributes.
+    ``host_type`` is a :class:`HostType` enum.
 
     The class also exposes a static method that checks whether the input
     *url* (and optional *base*) can be parsed:
@@ -149,7 +149,7 @@ class URL:
             if attr == 'origin':
                 ret = _get_str(data)
                 lib.ada_free_owned_string(data)
-            elif attr == 'url_host_type':
+            elif attr == 'host_type':
                 ret = data
             else:
                 ret = _get_str(data)
@@ -290,12 +290,12 @@ def parse_url(s, attributes=PARSE_ATTRIBUTES):
             'search': '?q=1',
             'hash': '#frag'
             'origin': 'https://example.org:8080',
-            'url_host_type': 0
+            'host_type': 0
         }
 
     The names of the dictionary keys correspond to the components of the "URL class"
     in the WHATWG URL spec.
-    ``url_host_type`` is a :class:`URLHostType` enum.
+    ``host_type`` is a :class:`HostType` enum.
 
     Pass in a sequence of *attributes* to limit which keys are returned.
 
@@ -325,8 +325,8 @@ def parse_url(s, attributes=PARSE_ATTRIBUTES):
         if attr == 'origin':
             ret[attr] = _get_str(data)
             lib.ada_free_owned_string(data)
-        elif attr == 'url_host_type':
-            ret[attr] = URLHostType(data)
+        elif attr == 'host_type':
+            ret[attr] = HostType(data)
         else:
             ret[attr] = _get_str(data)
 

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -18,6 +18,7 @@ PARSE_ATTRIBUTES = URL_ATTRIBUTES + ('origin', 'host_type')
 
 GET_ATTRIBUTES = frozenset(PARSE_ATTRIBUTES)
 SET_ATTRIBUTES = frozenset(URL_ATTRIBUTES)
+DELETE_ATTRIBUTES = frozenset(('port', 'hash', 'pathname', 'search'))
 
 
 class HostType(IntEnum):
@@ -138,6 +139,13 @@ class URL:
         ret.urlobj = lib.ada_copy(self.urlobj)
 
         return ret
+
+    def __delattr__(self, attr):
+        if attr in DELETE_ATTRIBUTES:
+            clear_func = getattr(lib, f'ada_clear_{attr}')
+            clear_func(self.urlobj)
+        else:
+            super().__delattr__(attr)
 
     def __dir__(self):
         return super().__dir__() + list(PARSE_ATTRIBUTES)

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -151,8 +151,6 @@ class URL:
         return ret
 
     def __delattr__(self, attr):
-        if attr == 'pathname':
-            lib.ada_set_pathname(self.urlobj, b'', 0)
         if attr in CLEAR_ATTRIBUTES:
             clear_func = getattr(lib, f'ada_clear_{attr}')
             clear_func(self.urlobj)

--- a/ada_url/ada_c.h
+++ b/ada_url/ada_c.h
@@ -51,6 +51,7 @@ bool ada_can_parse_with_base(const char* input, size_t input_length,
 
 void ada_free(ada_url result);
 void ada_free_owned_string(ada_owned_string owned);
+ada_url ada_copy(ada_url input);
 
 bool ada_is_valid(ada_url result);
 
@@ -67,6 +68,7 @@ ada_string ada_get_hostname(ada_url result);
 ada_string ada_get_pathname(ada_url result);
 ada_string ada_get_search(ada_url result);
 ada_string ada_get_protocol(ada_url result);
+uint8_t ada_get_url_host_type(ada_url result);
 
 // url_aggregator setters
 // if ada_is_valid(result)) is false, the setters have no effect

--- a/ada_url/ada_c.h
+++ b/ada_url/ada_c.h
@@ -87,7 +87,6 @@ void ada_set_hash(ada_url result, const char* input, size_t length);
 // url_aggregator clear methods
 void ada_clear_port(ada_url result);
 void ada_clear_hash(ada_url result);
-void ada_clear_pathname(ada_url result);
 void ada_clear_search(ada_url result);
 
 // url_aggregator functions

--- a/ada_url/ada_c.h
+++ b/ada_url/ada_c.h
@@ -68,7 +68,7 @@ ada_string ada_get_hostname(ada_url result);
 ada_string ada_get_pathname(ada_url result);
 ada_string ada_get_search(ada_url result);
 ada_string ada_get_protocol(ada_url result);
-uint8_t ada_get_url_host_type(ada_url result);
+uint8_t ada_get_host_type(ada_url result);
 
 // url_aggregator setters
 // if ada_is_valid(result)) is false, the setters have no effect
@@ -83,6 +83,12 @@ bool ada_set_port(ada_url result, const char* input, size_t length);
 bool ada_set_pathname(ada_url result, const char* input, size_t length);
 void ada_set_search(ada_url result, const char* input, size_t length);
 void ada_set_hash(ada_url result, const char* input, size_t length);
+
+// url_aggregator clear methods
+void ada_clear_port(ada_url result);
+void ada_clear_hash(ada_url result);
+void ada_clear_pathname(ada_url result);
+void ada_clear_search(ada_url result);
 
 // url_aggregator functions
 // if ada_is_valid(result) is false, functions below will return false

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,4 +49,13 @@ API Documentation
 =================
 
 .. automodule:: ada_url
-    :members:
+
+.. autoclass:: URL
+.. autoclass:: URLHostType()
+.. autofunction:: check_url
+.. autofunction:: join_url
+.. autofunction:: normalize_url
+.. autofunction:: parse_url
+.. autofunction:: replace_url
+.. autofunction:: idna
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ API Documentation
 .. automodule:: ada_url
 
 .. autoclass:: URL
-.. autoclass:: URLHostType()
+.. autoclass:: HostType()
 .. autofunction:: check_url
 .. autofunction:: join_url
 .. autofunction:: normalize_url

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from ada_url import (
     URL,
+    URLHostType,
     check_url,
     idna,
     idna_to_ascii,
@@ -10,7 +11,6 @@ from ada_url import (
     normalize_url,
     parse_url,
     replace_url,
-    URLHostType,
 )
 from ada_url.ada_adapter import GET_ATTRIBUTES
 

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -326,7 +326,13 @@ class ADAURLTests(TestCase):
                 actual = replace_url(s, **kwargs)
                 self.assertEqual(actual, expected)
 
-    def test_replace_blank(self):
+    def test_replace_url_clear(self):
+        s = 'https://user_1:password_1@example.org:8443/api?q=1#frag'
+        actual = replace_url(s, port='', hash='', search='')
+        expected = 'https://user_1:password_1@example.org/api'
+        self.assertEqual(actual, expected)
+
+    def test_replace_url_unset(self):
         s = 'https://user:pass@example.org'
         actual = replace_url(s, username='', password='')
         expected = 'https://example.org/'

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -10,6 +10,7 @@ from ada_url import (
     normalize_url,
     parse_url,
     replace_url,
+    URLHostType,
 )
 from ada_url.ada_adapter import GET_ATTRIBUTES
 
@@ -34,6 +35,18 @@ class ADAURLTests(TestCase):
 
         with self.assertRaises(AttributeError):
             urlobj.bogus
+
+    def test_class_url_host_type(self):
+        # url_host_type should return an IntEnum, which can be compared to a Python int
+        for url, expected in (
+            ('http://localhost:3000', URLHostType.DEFAULT),
+            ('http://0.0.0.0', URLHostType.IPV4),
+            ('http://[2001:db8:3333:4444:5555:6666:7777:8888]', URLHostType.IPV6),
+        ):
+            with self.subTest(url=url):
+                urlobj = URL(url)
+                self.assertEqual(urlobj.url_host_type, int(expected))
+                self.assertEqual(urlobj.url_host_type, expected)
 
     def test_class_set(self):
         url = 'https://username:password@www.google.com:8080/'
@@ -228,6 +241,7 @@ class ADAURLTests(TestCase):
             'search': '?q=1',
             'hash': '#frag',
             'origin': 'https://example.org:8080',
+            'url_host_type': 0,
         }
         self.assertEqual(actual, expected)
 

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -96,10 +96,28 @@ class ADAURLTests(TestCase):
         self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org/api?q=1')
 
         del urlobj.pathname
-        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org?q=1')
+        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org/?q=1')
 
         del urlobj.search
-        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org')
+        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org/')
+
+        with self.assertRaises(AttributeError):
+            del urlobj.href
+
+    def test_unset(self):
+        url = 'https://user_1:password_1@example.org:8080/dir/../api?q=1#frag'
+        for attr, expected in (
+            ('username', 'https://:password_1@example.org:8080/api?q=1#frag'),
+            ('password', 'https://user_1@example.org:8080/api?q=1#frag'),
+            ('port', 'https://user_1:password_1@example.org/api?q=1#frag'),
+            ('pathname', 'https://user_1:password_1@example.org:8080/?q=1#frag'),
+            ('search', 'https://user_1:password_1@example.org:8080/api#frag'),
+            ('hash', 'https://user_1:password_1@example.org:8080/api?q=1'),
+        ):
+            with self.subTest(attr=attr):
+                urlobj = URL(url)
+                urlobj.__delattr__(attr)
+                self.assertEqual(urlobj.href, expected)
 
     def test_class_with_base(self):
         url = '../example.txt'

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -1,3 +1,4 @@
+from copy import copy, deepcopy
 from unittest import TestCase
 
 from ada_url import (
@@ -47,6 +48,19 @@ class ADAURLTests(TestCase):
                 urlobj = URL(url)
                 self.assertEqual(urlobj.url_host_type, int(expected))
                 self.assertEqual(urlobj.url_host_type, expected)
+
+    def test_copy_vs_deepcopy(self):
+        obj = URL('http://example.org:8080')
+        copied_obj = copy(obj)
+        deepcopied_obj = deepcopy(obj)
+
+        obj.port = '8081'
+        self.assertEqual(copied_obj.port, '8081')
+        self.assertEqual(deepcopied_obj.port, '8080')
+
+        deepcopied_obj.port = '8082'
+        self.assertEqual(copied_obj.port, '8081')
+        self.assertEqual(deepcopied_obj.port, '8082')
 
     def test_class_set(self):
         url = 'https://username:password@www.google.com:8080/'

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -83,6 +83,24 @@ class ADAURLTests(TestCase):
         expected = 'wss://changed-host:9090/new-pathname?new-search#new-hash'
         self.assertEqual(actual, expected)
 
+    def test_class_delete(self):
+        url = 'https://user_1:password_1@example.org:8080/dir/../api?q=1#frag'
+        urlobj = URL(url)
+
+        del urlobj.port
+        self.assertEqual(
+            urlobj.href, 'https://user_1:password_1@example.org/api?q=1#frag'
+        )
+
+        del urlobj.hash
+        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org/api?q=1')
+
+        del urlobj.pathname
+        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org?q=1')
+
+        del urlobj.search
+        self.assertEqual(urlobj.href, 'https://user_1:password_1@example.org')
+
     def test_class_with_base(self):
         url = '../example.txt'
         base = 'https://example.org/path/'

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -2,8 +2,8 @@ from copy import copy, deepcopy
 from unittest import TestCase
 
 from ada_url import (
+    HostType,
     URL,
-    URLHostType,
     check_url,
     idna,
     idna_to_ascii,
@@ -37,17 +37,17 @@ class ADAURLTests(TestCase):
         with self.assertRaises(AttributeError):
             urlobj.bogus
 
-    def test_class_url_host_type(self):
-        # url_host_type should return an IntEnum, which can be compared to a Python int
+    def test_class_host_type(self):
+        # host_type should return an IntEnum, which can be compared to a Python int
         for url, expected in (
-            ('http://localhost:3000', URLHostType.DEFAULT),
-            ('http://0.0.0.0', URLHostType.IPV4),
-            ('http://[2001:db8:3333:4444:5555:6666:7777:8888]', URLHostType.IPV6),
+            ('http://localhost:3000', HostType.DEFAULT),
+            ('http://0.0.0.0', HostType.IPV4),
+            ('http://[2001:db8:3333:4444:5555:6666:7777:8888]', HostType.IPV6),
         ):
             with self.subTest(url=url):
                 urlobj = URL(url)
-                self.assertEqual(urlobj.url_host_type, int(expected))
-                self.assertEqual(urlobj.url_host_type, expected)
+                self.assertEqual(urlobj.host_type, int(expected))
+                self.assertEqual(urlobj.host_type, expected)
 
     def test_copy_vs_deepcopy(self):
         obj = URL('http://example.org:8080')
@@ -255,7 +255,7 @@ class ADAURLTests(TestCase):
             'search': '?q=1',
             'hash': '#frag',
             'origin': 'https://example.org:8080',
-            'url_host_type': 0,
+            'host_type': 0,
         }
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
This PR:
* Upgrades to the latest version of `ada_url`
* Adds the `host_type` to the `URL` class and to the `parse_url` function output
* Adds support for the `del` operator, using the `ada_clear_*` functions

The Host Type is returned as an `IntEnum`, whose values can be compared to normal integers.