### PR TITLE
Add scheme_type for ada 2.6.7

### DIFF
--- a/ada_url/__init__.py
+++ b/ada_url/__init__.py
@@ -1,6 +1,7 @@
 from ada_url.ada_adapter import (
-    URL,
     HostType,
+    SchemeType,
+    URL,
     check_url,
     idna,
     idna_to_ascii,
@@ -12,8 +13,9 @@ from ada_url.ada_adapter import (
 )
 
 __all__ = [
-    'URL',
     'HostType',
+    'SchemeType',
+    'URL',
     'check_url',
     'idna',
     'idna_to_ascii',

--- a/ada_url/ada.cpp
+++ b/ada_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-30 11:44:21 -0400. Do not edit! */
+/* auto-generated on 2023-09-05 14:59:23 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -15007,6 +15007,14 @@ uint8_t ada_get_host_type(ada_url result) noexcept {
     return 0;
   }
   return r->host_type;
+}
+
+uint8_t ada_get_schema_type(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (!r) {
+    return 0;
+  }
+  return r->type;
 }
 
 bool ada_set_href(ada_url result, const char* input, size_t length) noexcept {

--- a/ada_url/ada.cpp
+++ b/ada_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-09-05 14:59:23 -0400. Do not edit! */
+/* auto-generated on 2023-09-05 16:55:45 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -15009,7 +15009,7 @@ uint8_t ada_get_host_type(ada_url result) noexcept {
   return r->host_type;
 }
 
-uint8_t ada_get_schema_type(ada_url result) noexcept {
+uint8_t ada_get_scheme_type(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (!r) {
     return 0;

--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-30 11:44:21 -0400. Do not edit! */
+/* auto-generated on 2023-09-05 14:59:23 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -6926,14 +6926,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.5"
+#define ADA_VERSION "2.6.6"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 5,
+  ADA_VERSION_REVISION = 6,
 };
 
 }  // namespace ada

--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-09-05 14:59:23 -0400. Do not edit! */
+/* auto-generated on 2023-09-05 16:55:45 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -6926,14 +6926,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.6"
+#define ADA_VERSION "2.6.7"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 6,
+  ADA_VERSION_REVISION = 7,
 };
 
 }  // namespace ada

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -224,8 +224,7 @@ class URL:
 
     def __getattr__(self, attr: str) -> Union[str, HostType, SchemeType]:
         if attr in GET_ATTRIBUTES:
-            real_attr = 'schema_type' if (attr == 'scheme_type') else attr
-            get_func = getattr(lib, f'ada_get_{real_attr}')
+            get_func = getattr(lib, f'ada_get_{attr}')
             data = get_func(self.urlobj)
             if attr == 'origin':
                 ret = _get_str(data)
@@ -405,8 +404,7 @@ def parse_url(s: str, attributes: Iterable[str] = PARSE_ATTRIBUTES) -> ParseAttr
         raise ValueError('Invalid URL') from None
 
     for attr in attributes:
-        real_attr = 'schema_type' if (attr == 'scheme_type') else attr
-        get_func = getattr(lib, f'ada_get_{real_attr}')
+        get_func = getattr(lib, f'ada_get_{attr}')
         data = get_func(urlobj)
         if attr == 'origin':
             ret[attr] = _get_str(data)

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -55,7 +55,7 @@ class HostType(IntEnum):
 
 class SchemeType(IntEnum):
     """
-    Enum for URL scheme types:
+    Enum for `URL scheme types <https://url.spec.whatwg.org/#url-miscellaneous>`__.
 
     * ``HTTP`` URLs like ``http://example.org`` are ``0``.
     * ``NOT_SPECIAL`` URLs like ``git://example.og`` are ``1``.

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -31,6 +31,7 @@ UNSET_ATTRIBUTES = frozenset(('username', 'password', 'pathname'))
 
 _marker = object()
 
+
 class HostType(IntEnum):
     """
     Enum for URL host types:

--- a/ada_url/ada_c.h
+++ b/ada_url/ada_c.h
@@ -69,7 +69,7 @@ ada_string ada_get_pathname(ada_url result);
 ada_string ada_get_search(ada_url result);
 ada_string ada_get_protocol(ada_url result);
 uint8_t ada_get_host_type(ada_url result);
-uint8_t ada_get_schema_type(ada_url result);
+uint8_t ada_get_scheme_type(ada_url result);
 
 // url_aggregator setters
 // if ada_is_valid(result)) is false, the setters have no effect

--- a/ada_url/ada_c.h
+++ b/ada_url/ada_c.h
@@ -69,6 +69,7 @@ ada_string ada_get_pathname(ada_url result);
 ada_string ada_get_search(ada_url result);
 ada_string ada_get_protocol(ada_url result);
 uint8_t ada_get_host_type(ada_url result);
+uint8_t ada_get_schema_type(ada_url result);
 
 // url_aggregator setters
 // if ada_is_valid(result)) is false, the setters have no effect

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,13 +50,13 @@ API Documentation
 
 .. automodule:: ada_url
 
-.. autoclass:: URL
+.. autoclass:: URL(url, base=None)
 .. autoclass:: HostType()
 .. autoclass:: SchemeType()
-.. autofunction:: check_url
-.. autofunction:: join_url
-.. autofunction:: normalize_url
-.. autofunction:: parse_url
-.. autofunction:: replace_url
+.. autofunction:: check_url(s)
+.. autofunction:: join_url(base_url, s)
+.. autofunction:: normalize_url(s)
+.. autofunction:: parse_url(s, [attributes])
+.. autofunction:: replace_url(s, **kwargs)
 .. autoclass:: idna
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,10 +52,11 @@ API Documentation
 
 .. autoclass:: URL
 .. autoclass:: HostType()
+.. autoclass:: SchemeType()
 .. autofunction:: check_url
 .. autofunction:: join_url
 .. autofunction:: normalize_url
 .. autofunction:: parse_url
 .. autofunction:: replace_url
-.. autofunction:: idna
+.. autoclass:: idna
 

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from ada_url import (
     HostType,
+    SchemeType,
     URL,
     check_url,
     idna,
@@ -48,6 +49,22 @@ class ADAURLTests(TestCase):
                 urlobj = URL(url)
                 self.assertEqual(urlobj.host_type, int(expected))
                 self.assertEqual(urlobj.host_type, expected)
+
+    def test_class_scheme_type(self):
+        # host_type should return an IntEnum, which can be compared to a Python int
+        for url, expected in (
+            ('http://localhost', SchemeType.HTTP),
+            ('git://localhost', SchemeType.NOT_SPECIAL),
+            ('https://localhost', SchemeType.HTTPS),
+            ('ws://localhost', SchemeType.WS),
+            ('ftp://localhost', SchemeType.FTP),
+            ('wss://localhost', SchemeType.WSS),
+            ('file://localhost', SchemeType.FILE),
+        ):
+            with self.subTest(url=url):
+                urlobj = URL(url)
+                self.assertEqual(urlobj.scheme_type, int(expected))
+                self.assertEqual(urlobj.scheme_type, expected)
 
     def test_copy_vs_deepcopy(self):
         obj = URL('http://example.org:8080')
@@ -291,7 +308,8 @@ class ADAURLTests(TestCase):
             'search': '?q=1',
             'hash': '#frag',
             'origin': 'https://example.org:8080',
-            'host_type': 0,
+            'host_type': HostType(0),
+            'scheme_type': SchemeType(2),
         }
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
This PR adds support for the `ada_get_schema_type` added in [ada 2.6.6](https://github.com/ada-url/ada/pull/503). Per the discussion in that PR, I'll update this for the rename to `get_scheme_type` and adjust the code here to remove the adapter.

Update: now this PR uses 2.6.7.