### PR TITLE
Fix macOS arm64 and universal2 wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 
 .PHONY: c_lib
 c_lib:
-	$(CXX) -c "ada_url/ada.cpp" -fPIC -std="c++17" -O2 -o "ada_url/ada.o"
+	$(CXX) -c "ada_url/ada.cpp" -fPIC -std="c++17" -O2 -o "ada_url/ada.o" $(ARCHFLAGS)
 
 .PHONY: package
 package: c_lib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,12 @@ build = [
     "pp38-*",
     "pp39-*",
 ]
-before-all = "make c_lib"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
+before-all = "make c_lib"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET="10.15" }
+before-build = "make clean && make c_lib"


### PR DESCRIPTION
If we install ada_url on macOS M1 then we will get this error:

```
$ pip3 install ada_url==1.3.0
...

$ python3 -c "import ada_url"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../python/3.11.3/lib/python3.11/site-packages/ada_url/__init__.py", line 1, in <module>
    from ada_url.ada_adapter import (
  File ".../installs/python/3.11.3/lib/python3.11/site-packages/ada_url/ada_adapter.py", line 4, in <module>
    from ada_url._ada_wrapper import ffi, lib
ImportError: dlopen(.../installs/python/3.11.3/lib/python3.11/site-packages/ada_url/_ada_wrapper.abi3.so, 0x0002): symbol not found in flat namespace '_ada_can_parse'
```

GitHub Actions doesn’t support macOS arm64 (M1/Apple Silicon) managed runners, so we need to do cross-compilation on macOS. `cibuildwheel` sets `ARCHFLAGS` variable we can use with `CXX` compiler to set the correct target.

I decided to move `before-all` to `[tool.cibuildwheel.linux]` and add `before-build` to `[tool.cibuildwheel.macos]` for optimizing CI build time execution purposes.

We can’t use `before-all` in `[tool.cibuildwheel]` section because it will be running only once per platform (`linux`/`macos`), and we need to run it before all builds for all architectures for macOS (`x86_64`, `arm64`, `universal2`) because we will have different values for the `ARCHFLAGS` environment variable.

If we add `before-build` to `[tool.cibuildwheel]` then it will be executed many times for linux platform because builds are executed inside different docker containers and because we use QEMU then the compilation process is slow (GitHub Action Workflow execution time: 25 minutes vs 48 minutes).