### PR TITLE
Upgrade ada to 2.6.10, bump version to 1.5.0

### DIFF
--- a/ada_url/ada.cpp
+++ b/ada_url/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-09-19 16:48:25 -0400. Do not edit! */
+/* auto-generated on 2023-09-30 20:34:30 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -116,7 +116,7 @@ ada_really_inline constexpr bool verify_dns_length(
 
 ADA_PUSH_DISABLE_ALL_WARNINGS
 /* begin file src/ada_idna.cpp */
-/* auto-generated on 2023-08-29 15:28:19 -0400. Do not edit! */
+/* auto-generated on 2023-09-19 15:58:51 -0400. Do not edit! */
 /* begin file src/idna.cpp */
 /* begin file src/unicode_transcoding.cpp */
 
@@ -9505,18 +9505,19 @@ bool is_label_valid(const std::u32string_view label) {
 
 namespace ada::idna {
 
-bool constexpr begins_with(std::u32string_view view,
-                           std::u32string_view prefix) {
+bool begins_with(std::u32string_view view, std::u32string_view prefix) {
   if (view.size() < prefix.size()) {
     return false;
   }
+  // constexpr as of C++20
   return std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 
-bool constexpr begins_with(std::string_view view, std::string_view prefix) {
+bool begins_with(std::string_view view, std::string_view prefix) {
   if (view.size() < prefix.size()) {
     return false;
   }
+  // constexpr as of C++20
   return std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 
@@ -9809,6 +9810,17 @@ constexpr bool to_lower_ascii(char* input, size_t length) noexcept {
 #if ADA_NEON
 ada_really_inline bool has_tabs_or_newline(
     std::string_view user_input) noexcept {
+  // first check for short strings in which case we do it naively.
+  if (user_input.size() < 16) {  // slow path
+    for (size_t i = 0; i < user_input.size(); i++) {
+      if (user_input[i] == '\r' || user_input[i] == '\n' ||
+          user_input[i] == '\t') {
+        return true;
+      }
+    }
+    return false;
+  }
+  // fast path for long strings (expected to be common)
   size_t i = 0;
   const uint8x16_t mask1 = vmovq_n_u8('\r');
   const uint8x16_t mask2 = vmovq_n_u8('\n');
@@ -9821,9 +9833,8 @@ ada_really_inline bool has_tabs_or_newline(
                        vceqq_u8(word, mask3));
   }
   if (i < user_input.size()) {
-    uint8_t buffer[16]{};
-    memcpy(buffer, user_input.data() + i, user_input.size() - i);
-    uint8x16_t word = vld1q_u8((const uint8_t*)user_input.data() + i);
+    uint8x16_t word =
+        vld1q_u8((const uint8_t*)user_input.data() + user_input.length() - 16);
     running = vorrq_u8(vorrq_u8(running, vorrq_u8(vceqq_u8(word, mask1),
                                                   vceqq_u8(word, mask2))),
                        vceqq_u8(word, mask3));
@@ -9833,6 +9844,17 @@ ada_really_inline bool has_tabs_or_newline(
 #elif ADA_SSE2
 ada_really_inline bool has_tabs_or_newline(
     std::string_view user_input) noexcept {
+  // first check for short strings in which case we do it naively.
+  if (user_input.size() < 16) {  // slow path
+    for (size_t i = 0; i < user_input.size(); i++) {
+      if (user_input[i] == '\r' || user_input[i] == '\n' ||
+          user_input[i] == '\t') {
+        return true;
+      }
+    }
+    return false;
+  }
+  // fast path for long strings (expected to be common)
   size_t i = 0;
   const __m128i mask1 = _mm_set1_epi8('\r');
   const __m128i mask2 = _mm_set1_epi8('\n');
@@ -9846,9 +9868,8 @@ ada_really_inline bool has_tabs_or_newline(
         _mm_cmpeq_epi8(word, mask3));
   }
   if (i < user_input.size()) {
-    alignas(16) uint8_t buffer[16]{};
-    memcpy(buffer, user_input.data() + i, user_input.size() - i);
-    __m128i word = _mm_load_si128((const __m128i*)buffer);
+    __m128i word = _mm_loadu_si128(
+        (const __m128i*)(user_input.data() + user_input.length() - 16));
     running = _mm_or_si128(
         _mm_or_si128(running, _mm_or_si128(_mm_cmpeq_epi8(word, mask1),
                                            _mm_cmpeq_epi8(word, mask2))),

--- a/ada_url/ada.h
+++ b/ada_url/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-09-19 16:48:25 -0400. Do not edit! */
+/* auto-generated on 2023-09-30 20:34:30 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -8,7 +8,7 @@
 #define ADA_H
 
 /* begin file include/ada/ada_idna.h */
-/* auto-generated on 2023-08-29 15:28:19 -0400. Do not edit! */
+/* auto-generated on 2023-09-19 15:58:51 -0400. Do not edit! */
 /* begin file include/idna.h */
 #ifndef ADA_IDNA_H
 #define ADA_IDNA_H
@@ -129,9 +129,8 @@ std::string to_ascii(std::string_view ut8_string);
 // https://url.spec.whatwg.org/#forbidden-domain-code-point
 bool contains_forbidden_domain_code_point(std::string_view ascii_string);
 
-bool constexpr begins_with(std::u32string_view view,
-                           std::u32string_view prefix);
-bool constexpr begins_with(std::string_view view, std::string_view prefix);
+bool begins_with(std::u32string_view view, std::u32string_view prefix);
+bool begins_with(std::string_view view, std::string_view prefix);
 
 bool constexpr is_ascii(std::u32string_view view);
 bool constexpr is_ascii(std::string_view view);
@@ -6929,14 +6928,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.8"
+#define ADA_VERSION "2.6.10"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 8,
+  ADA_VERSION_REVISION = 10,
 };
 
 }  // namespace ada

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ada-url
-version = 1.4.1
+version = 1.5.0
 description = 'URL parser and manipulator based on the WHAT WG URL standard'
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
This PR upgrades `ada` to 2.6.10, and sets the version for this library to 1.5.0.