### PR TITLE
docs: fix install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Install from `PyPI <https://pypi.org/project/ada-url/>`__:
 
 .. code-block:: sh
 
-    pip install boto3-helpers
+    pip install ada_url
 
 Usage examples
 --------------


### PR DESCRIPTION
Fix the name of the package from `boto3-helpers` to `ada_url` in the installation instructions. 