### PR TITLE
Feat: Add  `len` builtin function to `URLSearchParams` class 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Install from `PyPI <https://pypi.org/project/ada-url/>`__:
 
 .. code-block:: sh
 
-    pip install boto3-helpers
+    pip install ada_url
 
 Usage examples
 --------------

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -349,6 +349,9 @@ class URLSearchParams:
     def size(self) -> int:
         return lib.ada_search_params_size(self.paramsobj)
 
+    def __len__(self) -> int:
+        return self.size
+
     def append(self, key: str, value: str):
         key_bytes = key.encode('utf-8')
         value_bytes = value.encode('utf-8')


### PR DESCRIPTION
This change aims to use the built-in function `len()` for getting the search params passed to the class `URLSearchParams`, instead of using the `size` property, `len` is a more pythonic and idiomatic way to retrieve a count of items.

## Example of usage
```python
>>> from ada_url import URLSearchParams
>>> obj = URLSearchParams('key1=value1&key2=value2&key2=value3')
>>> len(obj)
3
```