### PR TITLE
Feat: add windows wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-lates"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-lates"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Install from `PyPI <https://pypi.org/project/ada-url/>`__:
 
 .. code-block:: sh
 
-    pip install boto3-helpers
+    pip install ada_url
 
 Usage examples
 --------------


### PR DESCRIPTION
Aims to fix #24 .

Currently `cibuildwheel` supports windows builds.