### PR TITLE
ci: add Windows x64 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,7 @@ before-all = "make c_lib"
 archs = ["x86_64", "universal2", "arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET="10.15" }
 before-build = "make clean && make c_lib"
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]
+before-build = '"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat" && cl "ada_url\\ada.cpp" /c /nologo /Fo"ada_url\\ada.o" /O2 /GL /MD /W3 /EHsc /std:c++17'


### PR DESCRIPTION
Also aim to fix #24.
Thanks @plusiv for https://github.com/ada-url/ada-python/pull/46#issuecomment-1776388272, where he came up with the solution.

It's a little bit tricky: maybe `make` cannot work with `vcvars64.bat` to modify the env, so I use a long `before-build`.

And I don't know how to choose from `vcvars64.bat` and `vcvars32.bat` by the OS arch. So only x64 wheels are available.

----

Some questions:
* Why do we include `.o`, `.cpp`, `.c`, `.h` files in the wheels? Afaik, ada works well without them.
* `pip install ada_url --no-binary ada_url` will fail (on both Linux and Windows) because of the absence of `ada.o`, same as https://github.com/ada-url/ada-python/pull/46#issuecomment-1776388272. Maybe we can open a new issue for this?

----

[Microsoft Visual C++ 2015-2022 Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022) is needed at runtime.