### PR TITLE
Set up development environment with uv pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: requirements
 requirements:
-	python3 -m pip install -r requirements/development.txt
+	python3 -m pip install uv
+	uv pip install -r requirements/development.txt
 
 .PHONY: check
 check:


### PR DESCRIPTION
This PR changes our `Makfile` to use `uv pip` instead of `pip`.

Resolves #58 