### PR TITLE
Fix broken docs, add link to can_ada

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,9 +138,11 @@ Contrast that with the Python standard library's ``urlib.parse`` module:
     >>> parsed_url.path
     '/./path/../path2/'
 
-Alternative (can_ada)
------------
+Alternative Python bindings
+---------------------------
 
-The ada-python bindings are built on CFFI, an approach that has the binding between C and Python written in Python itself, which loses some of the performance benefits of using Ada in the first place when most of the time is spent just making the function call.
-
-The can_ada (Canadian Ada) is a different Python binding that uses pybind11 to generate the binding code, which is then compiled into a Python extension module. This approach has the potential to be much faster than the ada-python bindings. See  https://tkte.ch/articles/2024/03/15/parsing-urls-in-python.html
+This package uses `CFFI <https://github.com/ada-url/ada-python/>`__ to call
+the ``Ada`` library's functions, which has a performance cost.
+The alternative `can_ada <https://github.com/ada-url/ada-python/>`__ (Canadian Ada)
+package uses `pybind11 <https://pybind11.readthedocs.io/en/stable/>` to generate a
+Python extension module, which is more performant.

--- a/README.rst
+++ b/README.rst
@@ -144,5 +144,5 @@ Alternative Python bindings
 This package uses `CFFI <https://github.com/ada-url/ada-python/>`__ to call
 the ``Ada`` library's functions, which has a performance cost.
 The alternative `can_ada <https://github.com/ada-url/ada-python/>`__ (Canadian Ada)
-package uses `pybind11 <https://pybind11.readthedocs.io/en/stable/>` to generate a
+package uses `pybind11 <https://pybind11.readthedocs.io/en/stable/>`__ to generate a
 Python extension module, which is more performant.


### PR DESCRIPTION
[This change](https://github.com/ada-url/ada-python/commit/20e1c7daaf055af060c712231160afb6388d8642) was marked as `skip ci`, which unfortunately masked the Sphinx syntax issue:

```
docs/_build/README.pprst:142:Title underline too short.
```

This PR fixes that issue and also adds links in Sphinx syntax to the excellent `can_ada` package, as discussed in the earlier thread.