### PR TITLE
Use version specifiers for Sphinx requirements

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -39,9 +39,11 @@ requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.7.1
 snowballstemmer==2.2.0
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==1.0.4;python_version<"3.9"
+sphinxcontrib-applehelp==1.0.8;python_version>="3.9"
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.1;python_version<"3.9"
+sphinxcontrib-htmlhelp==2.0.5;python_version>="3.9"
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5


### PR DESCRIPTION
This PR is aimed at fixing the issue described [here](https://github.com/ada-url/ada-python/pull/72#issuecomment-2059515911). Hopefully Dependabot will get the idea.