### PR TITLE
More Sphinx pins for Dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
+        overwrite: true
 
   make_sdist:
     runs-on: "ubuntu-latest"
@@ -53,6 +54,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         path: dist/*.tar.gz
+        overwrite: true
 
   upload_all:
     needs: [build_wheels, make_sdist]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ on:
     types:
       - published
 
-env:
-  PIP_BREAK_SYSTEM_PACKAGES: 1
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -31,26 +28,26 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: make requirements
     - name: Set up QEMU  # Needed to build aarch64 wheels
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
       with:
         platforms: all
-    - uses: pypa/cibuildwheel@v2.16.5
-    - uses: actions/upload-artifact@v3
+    - uses: pypa/cibuildwheel@v2.17.0
+    - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
 
   make_sdist:
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         make requirements
         python -m build --no-isolation --sdist
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: dist/*.tar.gz
 
@@ -62,7 +59,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: make requirements req_args="--break-system-packages"
+    - run: make requirements
     - name: Set up QEMU  # Needed to build aarch64 wheels
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ on:
     types:
       - published
 
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: |
-        make requirements
+        make requirements req_args="--break-system-packages"
         python -m build --no-isolation --sdist
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ on:
     types:
       - published
 
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -45,7 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: |
-        make requirements req_args="--break-system-packages"
+        make requirements
         python -m build --no-isolation --sdist
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: make requirements
+    - run: make requirements req_args="--break-system-packages"
     - name: Set up QEMU  # Needed to build aarch64 wheels
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: requirements
 requirements:
-	python3 -m pip install -r requirements/development.txt
+	python3 -m pip install -r requirements/development.txt ${req_args}
 
 .PHONY: check
 check:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,4 +2,4 @@
 cffi==1.16.0
 
 # What we need
-pycparser==2.21
+pycparser==2.22

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,7 +8,8 @@ twine==5.0.0
 wheel==0.43.0
 
 # What we need
-alabaster==0.7.13
+alabaster==0.7.13;python_version<"3.9"
+alabaster==0.7.16;python_version>="3.9"
 Babel==2.14.0
 backports.tarfile==1.0.0
 certifi==2024.2.2
@@ -41,12 +42,14 @@ rich==13.7.1
 snowballstemmer==2.2.0
 sphinxcontrib-applehelp==1.0.4;python_version<"3.9"
 sphinxcontrib-applehelp==1.0.8;python_version>="3.9"
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.2;python_version<"3.9"
+sphinxcontrib-devhelp==1.0.6;python_version>="3.9"
 sphinxcontrib-htmlhelp==2.0.1;python_version<"3.9"
 sphinxcontrib-htmlhelp==2.0.5;python_version>="3.9"
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.5;python_version<"3.9"
+sphinxcontrib-serializinghtml==1.1.10;python_version>="3.9"
 tomli==2.0.1
 typing_extensions==4.11.0
 urllib3==2.2.1


### PR DESCRIPTION
Similar to PR #76, this one pins additional dependencies with different versions for 3.8 and 3.9+.

Python 3.8 goes EOL in October, so this will probably stop happening then.