### PR TITLE
Set minimum cffi version instead of maximum setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["cffi", "setuptools < 74", "urllib3", "wheel"]
+requires = ["cffi>=1.17.1", "setuptools", "urllib3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -83,3 +83,8 @@ before-build = "make clean && make c_lib"
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
 before-build = '"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat" && cl "ada_url\\ada.cpp" /c /nologo /Fo"ada_url\\ada.o" /O2 /GL /MD /W3 /EHsc /std:c++17'
+
+# https://github.com/pypy/pypy/issues/5027
+[[tool.cibuildwheel.overrides]]
+select = "pp39-win_amd64"
+environment = { SETUPTOOLS_USE_DISTUTILS="stdlib" }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # What we want
-cffi==1.17.0
+cffi==1.17.1
 
 # What we need
 pycparser==2.22

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,7 +1,7 @@
 build
 coverage
 ruff
-setuptools<74
+setuptools
 Sphinx
 twine
 urllib3


### PR DESCRIPTION
The latest cffi version fixes the incompatibility with setuptools version 74 and above.