### PR TITLE
Drop 3.8-specific items

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         make requirements

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,5 @@
 name: Unit tests
+name: Unit tests
 
 on:
   pull_request:
@@ -28,10 +29,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         make requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = 'URL parser and manipulator based on the WHAT WG URL standard'
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "Apache 2.0"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -35,14 +35,9 @@ include-package-data = true
 [tool.setuptools.package-data]
 ada_url = ["*.c", "*.h", "*.o"]
 
-[tool.black]
-line-length = 88
-target-version = ['py38']
-skip-string-normalization = true
-
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 exclude = [
     ".git",
     ".ruff_cache",
@@ -62,13 +57,11 @@ include = [
 
 [tool.cibuildwheel]
 build = [
-    "cp38-*",
     "cp39-*",
     "cp310-*",
     "cp311-*",
     "cp312-*",
     "cp313-*",
-    "pp38-*",
     "pp39-*",
     "pp310-*",
 ]


### PR DESCRIPTION
Python 3.8 went end of life on the 7th. This PR drops testing for that version, which was preventing some upgrades of development dependencies (particularly Sphinx for docs).