### PR TITLE
Update type hint for idna.encode

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -743,7 +743,7 @@ class idna:
         return _get_str(data)
 
     @staticmethod
-    def encode(s: Union[str, bytes]) -> str:
+    def encode(s: Union[str, bytes]) -> bytes:
         if isinstance(s, str):
             s = s.encode()
 


### PR DESCRIPTION
This PR fixes the type hint for `idna.encode`. Closes #106.