### PR TITLE
Issue 126: redact passwords in repr

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -271,7 +271,11 @@ class URL:
         return self.href
 
     def __repr__(self):
-        return f'<URL "{self.href}">'
+        password = self.password
+        self.password = ''
+        ret = f'<URL "{self.href}">'
+        self.password = password
+        return ret
 
     @staticmethod
     def can_parse(url: str, base: Optional[str] = None) -> bool:
@@ -754,6 +758,7 @@ class idna:
 idna_to_unicode = idna.decode
 
 idna_to_ascii = idna.encode
+
 
 def get_version():
     return ffi.string(lib.ada_get_version()).decode()

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -194,6 +194,15 @@ class ADAURLTests(TestCase):
         expected = '<URL "https://example.org/something.txt">'
         self.assertEqual(actual, expected)
 
+    def test_to_repr_password(self):
+        # Redact the password attribute from __repr__, but keep it on the object.
+        urlobj = URL('https://user:password1@example.org/../something.txt')
+        self.assertEqual(repr(urlobj), '<URL "https://user@example.org/something.txt">')
+        self.assertEqual(urlobj.password, 'password1')
+        self.assertEqual(
+            str(urlobj), 'https://user:password1@example.org/something.txt'
+        )
+
     def test_check_url(self):
         for s, expected in (
             ('https:example.org', True),
@@ -555,6 +564,6 @@ class GetVersionTests(TestCase):
     def test_get_version(self):
         value = get_version()
         version_parts = value.split('.')
-        self.assertEqual(len(version_parts), 3) # Three parts
+        self.assertEqual(len(version_parts), 3)  # Three parts
         int(version_parts[0])  # Major should be an integer
         int(version_parts[1])  # Minor should be an integer


### PR DESCRIPTION
This PR updates the `__repr__` method for `URL` objects such that the `password` attribute is not exposed.


```python
    def test_to_repr_password(self):
        # Redact the password attribute from __repr__, but keep it on the object.
        urlobj = URL('https://user:password1@example.org/../something.txt')
        self.assertEqual(repr(urlobj), '<URL "https://user@example.org/something.txt">')
        self.assertEqual(urlobj.password, 'password1')
        self.assertEqual(
            str(urlobj), 'https://user:password1@example.org/something.txt'
        )
```

Closes #126.