### PR TITLE
Make a copy for __repr__

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from enum import IntEnum
 from typing import (
     Dict,
@@ -271,11 +272,9 @@ class URL:
         return self.href
 
     def __repr__(self):
-        password = self.password
-        self.password = ''
-        ret = f'<URL "{self.href}">'
-        self.password = password
-        return ret
+        duplicate = deepcopy(self)
+        duplicate.password = ''
+        return f'<URL "{duplicate.href}">'
 
     @staticmethod
     def can_parse(url: str, base: Optional[str] = None) -> bool:

--- a/ada_url/ada_build.py
+++ b/ada_url/ada_build.py
@@ -10,7 +10,7 @@ compile_args = ['/std:c++20'] if platform == 'win32' else ['-std=c++20']
 ada_obj = Extension(
     'ada',
     define_macros=[('ADA_INCLUDE_URL_PATTERN', '0')],
-    language="c++",
+    language='c++',
     sources=['ada_url/ada.cpp'],
     include_dirs=[file_dir],
     extra_compile_args=compile_args,

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ class build_ext(_build_ext):
                 ext.extra_objects[i] = objects[0]
         return super().build_extension(ext)
 
+
 setup(
     cmdclass={'build_ext': build_ext},
     cffi_modules=[

--- a/update_sdist.py
+++ b/update_sdist.py
@@ -3,6 +3,7 @@ update_sdist.py
 
 Run this script to remove compiled artifacts from source distribution tarballs.
 """
+
 from pathlib import Path
 from tarfile import open as tar_open
 from tempfile import TemporaryDirectory


### PR DESCRIPTION
More on issue #127, this PR switches to making a copy of the whole object to avoid introducing thread safety issues.