### PR TITLE
Version 1.32.0

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -395,14 +395,16 @@ class URLSearchParams:
         return _get_str(item)
 
     def get_all(self, key: str) -> List[str]:
+        ret = []
         key_bytes = key.encode()
         items = lib.ada_search_params_get_all(self.paramsobj, key_bytes, len(key_bytes))
-        count = lib.ada_strings_size(items)
-
-        ret = []
-        for i in range(count):
-            value = _get_str(lib.ada_strings_get(items, i))
-            ret.append(value)
+        try:
+            count = lib.ada_strings_size(items)
+            for i in range(count):
+                value = _get_str(lib.ada_strings_get(items, i))
+                ret.append(value)
+        finally:
+            lib.ada_free_strings(items)
 
         return ret
 

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -216,7 +216,7 @@ class URL:
         cls = self.__class__
         ret = cls.__new__(cls)
         super(URL, ret).__init__()
-        ret.urlobj = lib.ada_copy(self.urlobj)
+        ret.urlobj = _get_obj(lib.ada_copy, lib.ada_free, self.urlobj)
 
         return ret
 

--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -116,8 +116,7 @@ def _get_obj(constructor, destructor, *args):
 
 
 def _get_str(x):
-    ret = ffi.string(x.data, x.length).decode() if x.length else ''
-    return ret
+    return bytes(ffi.buffer(x.data, x.length)).decode() if x.length else ''
 
 
 class URL:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ada-url"
-version = "1.31.0"
+version = "1.32.0"
 authors = [
     {name = "Bo Bayles", email = "bo@bbayles.com"},
 ]

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -531,6 +531,13 @@ class SearchParamsTests(TestCase):
         expected = 'key2=value3&key1=value4&key1=value5'
         self.assertEqual(actual, expected)
 
+    def test_null_handling(self):
+        evil_input = 'admin\x00hidden=true&safe=value'
+        params = SearchParams(evil_input)
+        actual = list(params.keys())
+        expected = ['admin\x00hidden', 'safe']
+        self.assertEqual(actual, expected)
+
 
 class ParseTests(TestCase):
     def test_url_suite(self):


### PR DESCRIPTION
This PR has some fixes for some potential issues:
* `ffi.string` assumes null-terminate C strings, which may not be appropriate for all input.
* The `ada_copy` call in `__deepcopy__` should have been paired with an `ada_free`.
* Similarly, `ada_free_strings` should have been called in `URLSearchParams.get_all`