### PR TITLE
Version 1.31.1

### DIFF
--- a/ada_url/ada_adapter.py
+++ b/ada_url/ada_adapter.py
@@ -273,7 +273,8 @@ class URL:
 
     def __repr__(self):
         duplicate = deepcopy(self)
-        duplicate.password = ''
+        if duplicate.password:
+            duplicate.password = ''
         return f'<URL "{duplicate.href}">'
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ada-url"
-version = "1.31.0"
+version = "1.31.1"
 authors = [
     {name = "Bo Bayles", email = "bo@bbayles.com"},
 ]

--- a/tests/test_ada_url.py
+++ b/tests/test_ada_url.py
@@ -203,6 +203,10 @@ class ADAURLTests(TestCase):
             str(urlobj), 'https://user:password1@example.org/something.txt'
         )
 
+    def test_repr_file(self):
+        url = URL('file:///')
+        repr(url)
+
     def test_check_url(self):
         for s, expected in (
             ('https:example.org', True),


### PR DESCRIPTION
This PR:
* Fixes `repr` for `file://` URLs.
* Bumps the version to 1.31.1.

Closes #131